### PR TITLE
Add a Unix newline at the end of files.

### DIFF
--- a/lib/rstrip/rstrip.rb
+++ b/lib/rstrip/rstrip.rb
@@ -19,7 +19,7 @@ module Rstrip
           end
         end
         File.open(file_path, 'w') do |file|
-          file.write(content.rstrip)
+          file.write(content.rstrip + "\n")
         end
       end
 


### PR DESCRIPTION
It is traditional for files to end with a newline character. Some
command line utilities will not read the last line of a file if it
does not end with a newline character.

Many text editors like VIM and Sublime Text automatically add
newlines to the end of created files and many diff tools display
"No newline at end of file" if a newline is not present.
